### PR TITLE
Adding reference CWMN collection to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,15 @@ Multiple files can be passed in at once
 
 ### Western
 
-To convert MEI files written in Western Musical Notation, run 
+To convert MEI files written in Common Western Music Notation (CWMN), run
 
 `mei2vol -W filename1.mei`
+
+All of the CWMN files processed by this library (so far) come from [this collection](https://github.com/DDMAL/Andrew-Hughes-Chant/tree/master/file_structure_text_file_MEI_file). Thus, we followed the conventions of those files. Namely:
+
+- Every neume is encoded as a quarter note
+- Stemless notes
+
 
 ### Mutiple MEI File Runs
 


### PR DESCRIPTION
For someone who is not familiarized with this repo or our lab meetings, it is not obvious to know where those CWMN `mei` files came from.

Adding at least a reference to the collection of scores.

Feel free to edit the unordered list accordingly.